### PR TITLE
Add segues to BookDetailViewController

### DIFF
--- a/BetterReads/BetterReads/Storyboards/Base.lproj/Main.storyboard
+++ b/BetterReads/BetterReads/Storyboards/Base.lproj/Main.storyboard
@@ -129,7 +129,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="1000"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UwA-YK-r6A" userLabel="ContentView">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1054"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1065.3333333333333"/>
                                         <subviews>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Owr-0V-qP7">
                                                 <rect key="frame" x="20" y="130" width="374" height="32"/>
@@ -149,19 +149,19 @@
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="BR6-EK-6gl" userLabel="UserStackView">
-                                                <rect key="frame" x="20" y="200.99999999999997" width="374" height="356.33333333333326"/>
+                                                <rect key="frame" x="20" y="201.00000000000003" width="374" height="365.66666666666674"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="rF4-p1-s7U" userLabel="FullName Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="84.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="87.666666666666671"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PEY-vW-qu1">
-                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="22"/>
                                                                 <fontDescription key="fontDescription" name="FrankRuhlLibre-Regular" family="Frank Ruhl Libre" pointSize="17"/>
                                                                 <color key="textColor" red="0.25098039220000001" green="0.25098039220000001" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Jane Smith" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="10h-Nb-0XN">
-                                                                <rect key="frame" x="0.0" y="24" width="374" height="40"/>
+                                                                <rect key="frame" x="0.0" y="26" width="374" height="40"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="40" id="aMQ-GQ-dit"/>
                                                                 </constraints>
@@ -169,7 +169,7 @@
                                                                 <textInputTraits key="textInputTraits" returnKeyType="next" textContentType="name"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name Error Message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9kO-uI-Mvx">
-                                                                <rect key="frame" x="0.0" y="68" width="374" height="16.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="70" width="374" height="17.666666666666671"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                 <color key="textColor" red="0.89019607840000003" green="0.20392156859999999" blue="0.20392156859999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -177,16 +177,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="PKy-5F-0Oz" userLabel="Email Stack View">
-                                                        <rect key="frame" x="0.0" y="89.333333333333314" width="374" height="84.333333333333314"/>
+                                                        <rect key="frame" x="0.0" y="92.666666666666686" width="374" height="87.666666666666686"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ux6-u6-N28">
-                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="22"/>
                                                                 <fontDescription key="fontDescription" name="FrankRuhlLibre-Regular" family="Frank Ruhl Libre" pointSize="17"/>
                                                                 <color key="textColor" red="0.25098039220000001" green="0.25098039220000001" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="janesmith@email.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9aL-Hg-XuH">
-                                                                <rect key="frame" x="0.0" y="24" width="374" height="40"/>
+                                                                <rect key="frame" x="0.0" y="26" width="374" height="40"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="40" id="5dY-KK-C5O"/>
                                                                 </constraints>
@@ -194,7 +194,7 @@
                                                                 <textInputTraits key="textInputTraits" keyboardType="emailAddress" returnKeyType="next" textContentType="email"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Error Message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ctn-5m-dTW">
-                                                                <rect key="frame" x="0.0" y="68" width="374" height="16.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="70" width="374" height="17.666666666666671"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                 <color key="textColor" red="0.89019607840000003" green="0.20392156859999999" blue="0.20392156859999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -202,19 +202,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Hqd-w1-CRK" userLabel="Password Stack View">
-                                                        <rect key="frame" x="0.0" y="178.66666666666669" width="374" height="86.333333333333314"/>
+                                                        <rect key="frame" x="0.0" y="185.33333333333331" width="374" height="87.666666666666686"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="34N-aL-wKz" userLabel="Horizontal Stack View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="22"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NX5-9s-JnK">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="75.333333333333329" height="22"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="69.333333333333329" height="22"/>
                                                                         <fontDescription key="fontDescription" name="FrankRuhlLibre-Regular" family="Frank Ruhl Libre" pointSize="17"/>
                                                                         <color key="textColor" red="0.25098039220000001" green="0.25098039220000001" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hQ3-Y9-XlB" userLabel="Info Button">
-                                                                        <rect key="frame" x="79.333333333333343" y="0.0" width="294.66666666666663" height="22"/>
+                                                                        <rect key="frame" x="73.333333333333343" y="0.0" width="300.66666666666663" height="22"/>
                                                                         <color key="tintColor" red="0.45098039220000002" green="0.45098039220000002" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <state key="normal" image="info.circle.fill" catalog="system"/>
                                                                         <connections>
@@ -232,7 +232,7 @@
                                                                 <textInputTraits key="textInputTraits" returnKeyType="next" textContentType="new-password"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Password Error Message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RKl-3e-6Ai">
-                                                                <rect key="frame" x="0.0" y="70" width="374" height="16.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="70" width="374" height="17.666666666666671"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                 <color key="textColor" red="0.89019607840000003" green="0.20392156859999999" blue="0.20392156859999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -240,19 +240,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="eZ2-Zr-6zK" userLabel="ConfirmPassword Stack View">
-                                                        <rect key="frame" x="0.0" y="270" width="374" height="86.333333333333314"/>
+                                                        <rect key="frame" x="0.0" y="278" width="374" height="87.666666666666686"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="oDS-Tv-q3M" userLabel="Horizontal Stack View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="22"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="098-Ld-TdH">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="139.66666666666666" height="22"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="133" height="22"/>
                                                                         <fontDescription key="fontDescription" name="FrankRuhlLibre-Regular" family="Frank Ruhl Libre" pointSize="17"/>
                                                                         <color key="textColor" red="0.25098039220000001" green="0.25098039220000001" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9hS-a4-rJR" userLabel="Info Button">
-                                                                        <rect key="frame" x="143.66666666666663" y="0.0" width="230.33333333333337" height="22"/>
+                                                                        <rect key="frame" x="137" y="0.0" width="237" height="22"/>
                                                                         <color key="tintColor" red="0.45098039220000002" green="0.45098039220000002" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <state key="normal" image="info.circle.fill" catalog="system"/>
                                                                         <connections>
@@ -270,7 +270,7 @@
                                                                 <textInputTraits key="textInputTraits" returnKeyType="done" textContentType="new-password"/>
                                                             </textField>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm Password Error Message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ve3-It-MEw">
-                                                                <rect key="frame" x="0.0" y="70" width="374" height="16.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="70" width="374" height="17.666666666666671"/>
                                                                 <fontDescription key="fontDescription" name="SourceSansPro-Regular" family="Source Sans Pro" pointSize="14"/>
                                                                 <color key="textColor" red="0.89019607840000003" green="0.20392156859999999" blue="0.20392156859999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -280,7 +280,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R5i-h0-MfM">
-                                                <rect key="frame" x="20" y="582.33333333333337" width="374" height="40"/>
+                                                <rect key="frame" x="20" y="591.66666666666663" width="374" height="40"/>
                                                 <color key="backgroundColor" red="0.25098039220000001" green="0.25098039220000001" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="hVY-uQ-9ni"/>
@@ -295,7 +295,7 @@
                                                 </connections>
                                             </button>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BetterReads-Graphics_Sitting" translatesAutoresizingMaskIntoConstraints="NO" id="MMk-Qt-2zY">
-                                                <rect key="frame" x="20" y="666.33333333333337" width="374" height="270"/>
+                                                <rect key="frame" x="20" y="677.66666666666663" width="374" height="270"/>
                                                 <color key="tintColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="MMk-Qt-2zY" secondAttribute="height" multiplier="187:135" id="WTd-Yt-2Iz"/>
@@ -304,7 +304,7 @@
                                                 </constraints>
                                             </imageView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mKe-xP-9Fu">
-                                                <rect key="frame" x="20" y="632.33333333333337" width="374" height="29"/>
+                                                <rect key="frame" x="20" y="641.66666666666663" width="374" height="31"/>
                                                 <fontDescription key="fontDescription" name="FrankRuhlLibre-Regular" family="Frank Ruhl Libre" pointSize="14"/>
                                                 <state key="normal" title="Forgot your password?">
                                                     <color key="titleColor" red="0.45098039220000002" green="0.45098039220000002" blue="0.45098039220000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -532,6 +532,7 @@
                                                                 <connections>
                                                                     <outlet property="activityIndicator" destination="ACi-J5-BUS" id="aii-yS-v78"/>
                                                                     <outlet property="bookCoverImageView" destination="1EK-77-Ugp" id="Nbm-gq-euH"/>
+                                                                    <segue destination="KfY-WO-sJ9" kind="show" identifier="ShowBookDetailSegue" id="rTd-to-6nz"/>
                                                                 </connections>
                                                             </collectionViewCell>
                                                         </cells>
@@ -615,6 +616,7 @@
                                                                 </collectionViewCellContentView>
                                                                 <connections>
                                                                     <outlet property="bookCoverImageView" destination="TIO-IA-ihl" id="nXR-hz-QaH"/>
+                                                                    <segue destination="KfY-WO-sJ9" kind="show" identifier="ShowBookDetailSegue" id="Anw-HX-Ft2"/>
                                                                 </connections>
                                                             </collectionViewCell>
                                                         </cells>
@@ -698,6 +700,7 @@
                                                                 </collectionViewCellContentView>
                                                                 <connections>
                                                                     <outlet property="bookCoverImageView" destination="m1W-2k-kFT" id="wVx-WX-pCt"/>
+                                                                    <segue destination="KfY-WO-sJ9" kind="show" identifier="ShowBookDetailSegue" id="WQ3-sy-enq"/>
                                                                 </connections>
                                                             </collectionViewCell>
                                                         </cells>
@@ -1030,6 +1033,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
+        <segue reference="rTd-to-6nz"/>
         <segue reference="Q4w-Qa-WfN"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/BetterReads/BetterReads/View Controllers/BookDetailViewController.swift
+++ b/BetterReads/BetterReads/View Controllers/BookDetailViewController.swift
@@ -170,6 +170,7 @@ class BookDetailViewController: UIViewController {
         super.viewDidLoad()
         title = ""
         print("intrinsicContentSize = \(self.view.intrinsicContentSize)")
+        navigationController?.navigationBar.isHidden = false
         setupSubviews()
     }
     

--- a/BetterReads/BetterReads/View Controllers/HomeViewController.swift
+++ b/BetterReads/BetterReads/View Controllers/HomeViewController.swift
@@ -22,6 +22,10 @@ class HomeViewController: UIViewController, UICollectionViewDataSource {
     @IBOutlet weak var bottomCollectionView: UICollectionView!
 
     //MARK: - Lifecycle
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.navigationBar.isHidden = true
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.isHidden = true
@@ -82,6 +86,19 @@ class HomeViewController: UIViewController, UICollectionViewDataSource {
             return cell
         }
         return RecommendationCollectionViewCell()
+    }
+
+    //MARK: - Navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "ShowBookDetailSegue" {
+            guard let barViewControllers = segue.destination as? UITabBarController,
+                let nav = barViewControllers.viewControllers?[0] as? UINavigationController,
+                let _ = nav.topViewController as? BookDetailViewController else {
+                //FIXME: - Better error handling and alert
+                //FIXME: - Give book to destinationVC when BookDetails is built
+                return
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Description
- Hide navigation controller on home screen.
- Unhide navigation controller on book details screen.
- Add segues from recommendations on HomeScreen to BookDetailViewController.

Trello card: https://trello.com/c/NhkKTlcS/67-home-screen

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change Status
- [x] Complete, tested, ready to review and merge

## How Has This Been Tested?
- [x] Manually tested with simulator (iPhone 8)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] There are no merge conflicts
