### PR TITLE
adds segue identifiers to all segues going to detailVC

### DIFF
--- a/BetterReads/BetterReads/Storyboards/Base.lproj/Main.storyboard
+++ b/BetterReads/BetterReads/Storyboards/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pRd-tq-Kku">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -126,7 +126,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="guE-28-28E">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="999.99999999999989"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="1000"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UwA-YK-r6A" userLabel="ContentView">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="1065.3333333333333"/>
@@ -809,7 +809,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </collectionViewCellContentView>
                                 <connections>
-                                    <segue destination="KfY-WO-sJ9" kind="show" id="13q-cF-JSj"/>
+                                    <segue destination="KfY-WO-sJ9" kind="show" identifier="ShelfToDetail" id="13q-cF-JSj"/>
                                 </connections>
                             </collectionViewCell>
                         </cells>
@@ -831,7 +831,7 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pah-8L-GHs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1013" y="2260"/>
+            <point key="canvasLocation" x="1012" y="2411"/>
         </scene>
         <!--Book Details-->
         <scene sceneID="aeV-sS-U0h">
@@ -847,7 +847,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8rX-fA-r9P" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1706" y="2260"/>
+            <point key="canvasLocation" x="2096" y="2260"/>
         </scene>
         <!--My Library-->
         <scene sceneID="zcO-xC-gwK">
@@ -872,7 +872,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </collectionViewCellContentView>
                                 <connections>
-                                    <segue destination="7Ac-R4-NMw" kind="show" id="hg3-I5-mNb"/>
+                                    <segue destination="7Ac-R4-NMw" kind="show" identifier="LibraryToShelf" id="hg3-I5-mNb"/>
                                 </connections>
                             </collectionViewCell>
                         </cells>
@@ -930,6 +930,7 @@
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="mainView" destination="VtS-wH-uqW" id="PT6-cs-dKV"/>
+                                    <segue destination="KfY-WO-sJ9" kind="show" identifier="SearchToDetail" id="F34-NN-b5M"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -1033,7 +1034,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="rTd-to-6nz"/>
+        <segue reference="WQ3-sy-enq"/>
         <segue reference="Q4w-Qa-WfN"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/BetterReads/BetterReads/View Controllers/BookDetailViewController.swift
+++ b/BetterReads/BetterReads/View Controllers/BookDetailViewController.swift
@@ -9,7 +9,8 @@
 import UIKit
 
 class BookDetailViewController: UIViewController {
-    
+    // FIXME: make back arrow white with no text
+    // FIXME: give intrinsicContentSize a value so it's not -1,-1
     // FIXME: make these properties with an ! at the end???
     let scrollView: UIScrollView = {
         let v = UIScrollView()

--- a/BetterReads/BetterReads/View Controllers/MyLibraryCollectionViewController.swift
+++ b/BetterReads/BetterReads/View Controllers/MyLibraryCollectionViewController.swift
@@ -58,15 +58,16 @@ class MyLibraryCollectionViewController: UICollectionViewController {
         super.viewDidLoad()
     }
 
-    /*
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "LibraryToShelf" {
+            print("LibraryToShelf")
+        }
         // Get the new view controller using [segue destinationViewController].
         // Pass the selected object to the new view controller.
     }
-    */
 
     // MARK: UICollectionViewDataSource
 
@@ -78,7 +79,7 @@ class MyLibraryCollectionViewController: UICollectionViewController {
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         // #warning Incomplete implementation, return the number of items
-        return libraryController.myBooksArray.count//tempShelfCount
+        return 1//libraryController.myBooksArray.count//tempShelfCount
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/BetterReads/BetterReads/View Controllers/SearchTableViewController.swift
+++ b/BetterReads/BetterReads/View Controllers/SearchTableViewController.swift
@@ -81,6 +81,9 @@ class SearchTableViewController: UITableViewController {
     // FIXME: add segue that goes to BookDetailViewController?
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "SearchToDetail" {
+            print("SearchToDetail")
+        }
         // Get the new view controller using segue.destination.
         // Pass the selected object to the new view controller.
     }

--- a/BetterReads/BetterReads/View Controllers/ShelfDetailCollectionViewController.swift
+++ b/BetterReads/BetterReads/View Controllers/ShelfDetailCollectionViewController.swift
@@ -27,15 +27,18 @@ class ShelfDetailCollectionViewController: UICollectionViewController {
 
     }
 
-    /*
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        //ShelfToDetail
+        if segue.identifier == "ShelfToDetail" {
+            print("ShelfToDetail")
+        }
         // Get the new view controller using [segue destinationViewController].
         // Pass the selected object to the new view controller.
     }
-    */
+    
 
     // MARK: UICollectionViewDataSource
 


### PR DESCRIPTION
# Description
Fixes Segues with no identifiers.
Adds segue identifiers to all segues going to detailVC, including searchTVC.

Trello card: https://trello.com/c/NsyqqgdM/66-library

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change Status
- [x] Complete, tested, ready to review and merge

## How Has This Been Tested?
- [x] Manually tested with simulator (iPhone 11)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
